### PR TITLE
Remove bogus default file which will crash the utility in case of not ha...

### DIFF
--- a/dfuse/DfuFile.py
+++ b/dfuse/DfuFile.py
@@ -63,5 +63,4 @@ class DfuFile:
             del(self.devInfo['crc'])
 
 
-DfuFile('../spiflash.dfu')
 


### PR DESCRIPTION
...ving such a file within the directory.

This has blocked using the tool in my case. Seems to be an srtifact.